### PR TITLE
bitvec+bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-[project]
+[package]
 name = "bloomfilter"
 version = "1.0.9"
 authors = ["Frank Denis <github@pureftpd.org>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ siphasher = "0.3.7"
 default = ["random"]
 random = ["getrandom"]
 serde = ["siphasher/serde_std", "bit-vec/serde"]
+bench = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/jedisct1/rust-bloom-filter"
 edition = "2018"
 
 [dependencies]
-bit-vec = "0.6.3"
-getrandom = { version = "0.2.3", optional = true }
-siphasher = "0.3.7"
+bitvec = "1.0.1"
+getrandom = { version = "0.2.8", optional = true }
+siphasher = "0.3.10"
 
 [features]
 default = ["random"]
 random = ["getrandom"]
-serde = ["siphasher/serde_std", "bit-vec/serde"]
+serde = ["siphasher/serde_std", "bitvec/serde"]
 bench = []

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,28 @@
+extern crate test;
+use super::Bloom;
+use test::Bencher;
+
+// launch with `cargo bench --features=bench`
+// only works with nightly, still marked unstable
+
+#[bench]
+fn bench_bloom_set_check_10_80(b: &mut Bencher) {
+    let mut bloom = Bloom::new(10, 80);
+    let mut i: usize = 0;
+    b.iter(|| {
+        bloom.set(&i);
+        _ = bloom.check(&i);
+        i += 1;
+    })
+}
+
+#[bench]
+fn bench_bloom_set_check_fp_rate_0_1(b: &mut Bencher) {
+    let mut bloom = Bloom::new_for_fp_rate(1_000_000, 0.1);
+    let mut i: usize = 0;
+    b.iter(|| {
+        bloom.set(&i);
+        _ = bloom.check(&i);
+        i += 1;
+    })
+}

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -18,7 +18,7 @@ fn bench_bloom_set_check_10_80(b: &mut Bencher) {
 
 #[bench]
 fn bench_bloom_set_check_fp_rate_0_1(b: &mut Bencher) {
-    let mut bloom = Bloom::new_for_fp_rate(1_000_000, 0.1);
+    let mut bloom = Bloom::new_for_fp_rate(1_000_000_000, 0.01);
     let mut i: usize = 0;
     b.iter(|| {
         bloom.set(&i);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,13 +164,8 @@ impl<T: ?Sized> Bloom<T> {
         let mut hashes = [0u64, 0u64];
         for k_i in 0..self.k_num {
             let bit_offset = (self.bloom_hash(&mut hashes, item, k_i) % self.bitmap_bits) as usize;
-            match self.bit_vec.get(bit_offset) {
-                Some(b) => {
-                    if !b {
-                        return false;
-                    }
-                }
-                None => return false,
+            if self.bit_vec.get(bit_offset).unwrap() == false {
+                return false;
             }
         }
         true
@@ -245,7 +240,7 @@ impl<T: ?Sized> Bloom<T> {
 
     /// Clear all of the bits in the filter, removing all keys from the set
     pub fn clear(&mut self) {
-        self.bit_vec.clear()
+        self.bit_vec.fill(false)
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 #![warn(non_camel_case_types, non_upper_case_globals, unused_qualifications)]
 #![allow(clippy::unreadable_literal, clippy::bool_comparison)]
+#![feature(test)]
 
 use bit_vec::BitVec;
 #[cfg(feature = "random")]
@@ -18,16 +19,20 @@ use std::f64;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 
+#[cfg(feature = "bench")]
+#[cfg(test)]
+mod bench;
+
 #[cfg(feature = "serde")]
 use siphasher::reexports::serde;
 
 pub mod reexports {
-    #[cfg(feature = "random")]
-    pub use ::getrandom;
     pub use bit_vec;
+    #[cfg(feature = "random")]
+    pub use getrandom;
+    pub use siphasher;
     #[cfg(feature = "serde")]
     pub use siphasher::reexports::serde;
-    pub use siphasher;
 }
 
 /// Bloom filter structure


### PR DESCRIPTION
Output on my laptop:

```
COMP-XMKG362QX5:rust-bloom-filter christian.mauduit$ git branch
  bench
  bitvec
* bitvec+bench
  master
COMP-XMKG362QX5:rust-bloom-filter christian.mauduit$ cargo bench --features=bench
    Finished bench [optimized] target(s) in 0.02s
     Running unittests src/lib.rs (target/release/deps/bloomfilter-30efd1de9b45620e)

running 6 tests
test bloom_test_check_and_set ... ignored
test bloom_test_clear ... ignored
test bloom_test_load ... ignored
test bloom_test_set ... ignored
test bench::bench_bloom_set_check_10_80       ... bench:          16 ns/iter (+/- 0)
test bench::bench_bloom_set_check_fp_rate_0_1 ... bench:         212 ns/iter (+/- 17)

test result: ok. 0 passed; 0 failed; 4 ignored; 2 measured; 0 filtered out; finished in 4.25s
```